### PR TITLE
Add basic analytics

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,9 +5,10 @@ import ENV from 'frontend-public-decisions/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service currentSession;
+  @service plausible;
 
   beforeModel() {
-    return this.loadCurrentSession();
+    return Promise.all([this.startAnalytics(), this.loadCurrentSession()]);
   }
 
   async sessionAuthenticated() {
@@ -41,5 +42,19 @@ export default class ApplicationRoute extends Route {
 
   loadCurrentSession() {
     return this.currentSession.load().catch(() => this.session.invalidate());
+  }
+
+  async startAnalytics() {
+    let { domain, apiHost } = ENV.plausible;
+
+    if (
+      domain !== '{{ANALYTICS_APP_DOMAIN}}' &&
+      apiHost !== '{{ANALYTICS_API_HOST}}'
+    ) {
+      await this.plausible.enable({
+        domain,
+        apiHost,
+      });
+    }
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -43,6 +43,15 @@ module.exports = function (environment) {
       l: 'nl',
       shift_page_down: false,
     },
+    // This config can be removed once the auto-startup logic is removed from ember-plausible:
+    // https://github.com/redpencilio/ember-plausible/issues/4
+    'ember-plausible': {
+      enabled: false,
+    },
+    plausible: {
+      domain: '{{ANALYTICS_APP_DOMAIN}}',
+      apiHost: '{{ANALYTICS_API_HOST}}',
+    },
   };
 
   if (environment === 'development') {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ember-moment": "^8.0.0",
     "ember-mu-transform-helpers": "^2.0.0",
     "ember-page-title": "^6.0.3",
+    "ember-plausible": "^0.1.0",
     "ember-power-select": "^4.0.0",
     "ember-promise-helpers": "^1.0.9",
     "ember-qunit": "^5.1.1",


### PR DESCRIPTION
This sets up Plausible support using ember-plausible. This allows us to easily add custom events in the future.

This conditionally enables the Plausible tracker. To enable this on a server we need to [replace](https://github.com/mu-semtech/static-file-service#how-to-configure-an-ember-application-at-runtime-using-environment-variables) the `{{ANALYTICS_APP_DOMAIN}}` and `{{ANALYTICS_API_HOST}}` strings with the real values before serving the app.