### PR TITLE
Create a contact form component and use it where needed

### DIFF
--- a/app/components/contact-form.hbs
+++ b/app/components/contact-form.hbs
@@ -1,0 +1,26 @@
+<form class="au-c-form" ...attributes>
+  <AuFieldset as |f|>
+    <f.legend>
+      Waar gaat uw bericht over?
+    </f.legend>
+    <f.content>
+      {{#each this.subjectOptions as |option|}}
+        <AuControlRadio
+          @label={{option.label}}
+          @name="message-subject"
+          @value={{option.subject}}
+          @onChange={{fn (mut this.selectedOption) option}}
+          @checked={{eq option.subject this.selectedOption.subject}}
+        />
+      {{/each}}
+    </f.content>
+  </AuFieldset>
+
+  {{#if this.canSend}}
+    <a href={{this.mailto}} class="au-c-button au-c-button--primary">
+      Stel bericht op
+    </a>
+  {{else}}
+    <AuButton @disabled={{true}}>Stel bericht op</AuButton>
+  {{/if}}
+</form>

--- a/app/components/contact-form.js
+++ b/app/components/contact-form.js
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class ContactFormComponent extends Component {
+  @tracked selectedOption = null;
+
+  subjectOptions = [
+    {
+      label: 'Een functionaliteit, bug of probleem',
+      subject: 'Functionaliteit, bug of probleem',
+    },
+    {
+      label: 'Een inhoudelijke vraag',
+      subject: 'Inhoudelijke vraag',
+    },
+  ];
+
+  get canSend() {
+    return Boolean(this.selectedOption);
+  }
+
+  get mailto() {
+    if (this.canSend) {
+      let subject = this.selectedOption.subject;
+
+      return `mailto:LoketLokaalBestuur@vlaanderen.be?subject=${subject} - Publieke besluitendatabank`;
+    } else {
+      return '';
+    }
+  }
+}

--- a/app/templates/contact.hbs
+++ b/app/templates/contact.hbs
@@ -1,26 +1,15 @@
 <main class="au-c-main-container__content au-c-main-container__content--scroll" id="content">
   <section class="au-o-region">
-    <div class="au-o-layout">
-      <AuHeading @level="1" @skin="1" class="au-u-margin-bottom">Contact</AuHeading>
-      <div class="au-o-region">
-        <form class="au-u-margin-bottom">
-          <AuLabel for="select">Waar gaat uw bericht over?</AuLabel>
+    <div class="au-o-layout au-o-flow">
+      <AuHeading @level="1" @skin="1">Contact</AuHeading>
+      <ContactForm />
 
-          {{!-- TODO: replace radio buttons with appuniversum radiobuttions --}}
-          <div class="au-o-region-small">
-            <WuRadioButton @label="Een functionaliteit, bug of probleem" @value="LoketLokaalBestuur@vlaanderen.be?subject=Functionaliteit of bug of probleem" @onChange={{fn (mut this.mailto)}} @isBlock={{true}} />
-            <WuRadioButton @label="Een inhoudelijke vraag" @value="LoketLokaalBestuur@vlaanderen.be?subject=Inhoudelijke vraag" @onChange={{fn (mut this.mailto)}} @isBlock={{true}} />
-          </div>
-
-          {{#if this.mailto}}
-            <a href={{concat "mailto:" this.mailto}} class="au-c-button au-c-button--large">Bericht versturen</a>
-          {{else}}
-            <AuButton @disabled="true" @size="large">Bericht versturen</AuButton>
-          {{/if}}
-        </form>
-
-        <p>Of neem rechtstreeks contact op via mail <a href="mailto:LoketLokaalBestuur@vlaanderen.be">LoketLokaalBestuur@vlaanderen.be</a>.</p>
-      </div>
+      <p>
+        Of neem rechtstreeks contact op via mail
+        <AuLinkExternal href="mailto:LoketLokaalBestuur@vlaanderen.be">
+          LoketLokaalBestuur@vlaanderen.be
+        </AuLinkExternal>.
+      </p>
     </div>
   </section>
   <AuMainFooter>

--- a/app/templates/help.hbs
+++ b/app/templates/help.hbs
@@ -99,28 +99,14 @@
         </AuCard>
       </div>
 
-      <div class="au-o-region">
-        <AuHeading @level="2" @skin="2" class="au-u-margin-bottom">
+      <div class="au-o-flow">
+        <AuHeading @level="2" @skin="2">
           Geen antwoord op uw vraag?
           <br>
           Neem contact met ons op!
         </AuHeading>
 
-          {{!-- TODO: replace radio buttons with appuniversum radiobuttions --}}
-        <form class="au-u-margin-bottom js-formvalidation-bound">
-          <AuLabel for="select">Waar gaat uw bericht over?</AuLabel>
-
-          <div class="au-o-region-small">
-            <WuRadioButton @label="Een functionaliteit, bug of probleem" @value="LoketLokaalBestuur@vlaanderen.be?subject=Functionaliteit of bug of probleem" @onChange={{fn (mut this.mailto)}} @isBlock={{true}} />
-            <WuRadioButton @label="Een inhoudelijke vraag" @value="LoketLokaalBestuur@vlaanderen.be?subject=Inhoudelijke vraag" @onChange={{fn (mut this.mailto)}} @isBlock={{true}} />
-          </div>
-
-          {{#if this.mailto}}
-            <a href={{concat "mailto:" this.mailto}} class="au-c-button au-c-button--large">Bericht versturen</a>
-          {{else}}
-            <AuButton @disabled="true" @size="large">Bericht versturen</AuButton>
-          {{/if}}
-        </form>
+        <ContactForm />
 
         <p>Of neem rechtstreeks contact op via mail <a href="mailto:LoketLokaalBestuur@vlaanderen.be" class="au-c-link">LoketLokaalBestuur@vlaanderen.be</a>.</p>
       </div>


### PR DESCRIPTION
This extracts the contact form markup and logic into a component so that it can be reused on both the help and contact page. We also replaced the Webuniversum components with Appuniversum equivalents.