### PR TITLE
Inject the `store` service where needed

### DIFF
--- a/app/controllers/mock-login.js
+++ b/app/controllers/mock-login.js
@@ -1,7 +1,10 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 import { restartableTask, task, timeout } from 'ember-concurrency';
 
 export default class MockLoginController extends Controller {
+  @service store;
+
   constructor() {
     super(...arguments);
   }

--- a/app/routes/search/submissions/search-queries/select.js
+++ b/app/routes/search/submissions/search-queries/select.js
@@ -10,6 +10,7 @@ import { FILTER_FORM_UUID } from '../../../../components/search-queries/filter-f
 
 export default class SearchSubmissionSearchQueriesSelectRoute extends Route {
   @service router;
+  @service store;
 
   async model(params) {
     const store = new ForkingStore();

--- a/app/routes/search/submissions/show.js
+++ b/app/routes/search/submissions/show.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SearchSubmissionsShowRoute extends Route {
+  @service store;
+
   model(params) {
     return this.store.findRecord('submission', params.id, {
       include: [


### PR DESCRIPTION
Implicit store injections are deprecated and are removed in Ember 4.