### PR TITLE
Remove ember-cli-string-helpers

### DIFF
--- a/app/components/search-queries/filter-form.hbs
+++ b/app/components/search-queries/filter-form.hbs
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="au-c-sidebar__footer au-c-sidebar__footer--border-top au-u-padding-none">
-    <AuToolbar @size="normal" style={{html-safe "min-height: 45px;"}} as |Group|>
+    <AuToolbar @size="normal" style="min-height: 45px;" {{! template-lint-disable no-inline-styles }} as |Group|>
       <Group>
         <AuButton @skin="tertiary" @alert="true" {{ on "click" (perform this.resetFilters) }}>
           <AuIcon @icon="redo" @alignment="left"/>

--- a/app/components/submissions/search-table.hbs
+++ b/app/components/submissions/search-table.hbs
@@ -1,6 +1,3 @@
-{{!-- template-lint-disable no-html-comments  --}}
-{{!-- template-lint-disable no-inline-styles  --}}
-
 <div class="au-c-body-container">
   <div class="au-o-grid au-o-grid--flush au-o-grid--fixed">
 
@@ -31,13 +28,14 @@
 
               <td class="au-u-visible-from@medium">{{row.province}}</td>
 
-              <td style={{html-safe "max-width: 175px;"}}>{{row.administrativeUnit}}
+              <td style="max-width: 175px;" {{! template-lint-disable no-inline-styles }}>
+                {{row.administrativeUnit}}
                 <p class="text-fade">{{row.administrativeUnitClassification}}</p>
               </td>
 
               <td class="au-u-visible-from@medium">{{row.administrativeUnitClassification}}</td>
 
-              <td style={{html-safe "max-width: 200px;"}}>
+              <td style="max-width: 200px;" {{! template-lint-disable no-inline-styles }}>
                 {{#if row.decisionType}}
                   <p>{{row.decisionType}}</p>
                 {{else}}
@@ -46,7 +44,7 @@
                 <AuHelpText>{{row.regulationType}}</AuHelpText>
               </td>
               <td class="au-u-visible-from@medium">{{moment-format row.sessionDatetime 'DD-MM-YYYY HH:mm'}}</td>
-              <td class="au-u-hide-on-print" style={{html-safe "width:70px;"}}>
+              <td class="au-u-hide-on-print" style="width:70px;" {{! template-lint-disable no-inline-styles }}>
                 <LinkTo @route="search.submissions.show" @model={{row.id}}>Bekijk</LinkTo>
               </td>
             </c.body>

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-string-helpers": "^6.1.0",
     "ember-cli-terser": "^4.0.2",
     "ember-cli-update": "^0.47.1",
     "ember-composable-helpers": "^5.0.0",


### PR DESCRIPTION
The `{{html-safe}}` helper was only used to bypass the no-inline-styles rule. Disabling the rule where needed is a better solution.