### PR TITLE
Fix the "reset filters" button

### DIFF
--- a/app/components/search-queries/filter-form.hbs
+++ b/app/components/search-queries/filter-form.hbs
@@ -3,15 +3,28 @@
     <div class="au-c-sidebar__header">
       {{#if this.init.isRunning}}
         <span>Aan het laden...</span>
+      {{else if this.resetFilters.isRunning}}
+        {{!
+            We render two different RdfForm component instances to work around the issue that graph changes don't affect local component state.
+            This forces Ember to destroy all field components and recreate them when the reset task is done.
+
+            TODO: This should be replaced by a better system.
+        }}
+        <RdfForm
+          @groupClass="au-o-grid__item au-u-1-2 au-u-1-1@small"
+          @form={{this.form}}
+          @graphs={{this.graphs}}
+          @sourceNode={{this.sourceNode}}
+          @formStore={{this.formStore}}
+          @forceShowErrors={{false}} />
       {{else}}
         <RdfForm
-                @groupClass="au-o-grid__item au-u-1-2 au-u-1-1@small"
-                @form={{this.form}}
-                @graphs={{this.graphs}}
-                @sourceNode={{this.sourceNode}}
-                @formStore={{this.formStore}}
-                @show={{if this.resetFilters.isRunning true false}}
-                @forceShowErrors={{false}} />
+          @groupClass="au-o-grid__item au-u-1-2 au-u-1-1@small"
+          @form={{this.form}}
+          @graphs={{this.graphs}}
+          @sourceNode={{this.sourceNode}}
+          @formStore={{this.formStore}}
+          @forceShowErrors={{false}} />
       {{/if}}
     </div>
   </div>


### PR DESCRIPTION
In previous releases of ember-submission-form-fields each field had both an "edit" and "show" version. We could (mis)use this behaviour to reset the form fields by temporarily switching the `@show` argument value.

Since a different component was being rendered in the read only mode, Ember throws away the edit component instances and recreates them when the `@show` flag was turned off. This had the effect that all form fields would reset.

When we deduplicated all of the form fields this trick no longer works since Ember doesn't destroy the component instances.

As a quick workaround we can temporarily render a new `RdfForm` instance so that all the components will be destroyed and recreated.