### PR TITLE
Appuniversum v2 update

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -27,3 +27,5 @@
     {{outlet}}
   </main>
 </AuApp>
+
+<AuModalContainer />

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,9 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
+    '@appuniversum/ember-appuniversum': {
+      disableWormholeElement: true,
+    },
   });
   // Use `app.import` to add additional libraries to the generated
   // output files.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-style-modifier": "^0.8.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.3.0",
+    "@appuniversum/ember-appuniversum": "^2.4.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",
     "@ember/test-helpers": "^2.6.0",
@@ -39,7 +39,7 @@
     "@glimmer/tracking": "^1.0.4",
     "@lblod/ember-acmidm-login": "^1.3.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-submission-form-fields": "^2.0.0",
+    "@lblod/ember-submission-form-fields": "^2.7.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.1",


### PR DESCRIPTION
ember-submission-form-fields v2.5.0 accidentally included a breaking change by requiring Appuniversum v2.3.0 in a minor release. Instead of rolling that breaking change back it seems easier to simply update all the apps that still depend on Appuniversum v1.