### PR TITLE
Update the EmberData setup

### DIFF
--- a/app/components/submissions/form.js
+++ b/app/components/submissions/form.js
@@ -1,4 +1,3 @@
-import { warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -26,13 +25,15 @@ export default class SubmissionsFormComponent extends Component {
 
   @task
   *loadData() {
-    const submission = yield this.args.submission;
+    const submission = this.args.submission;
     // Fetch data from backend
-    const submissionDocument = yield submission.submissionDocument;
+    yield submission.belongsTo('submissionDocument').reload();
+
+    const submissionDocument = submission.submissionDocument;
 
     if (!submissionDocument) {
-      warn('No submission document. Transitioning to index.');
-      this.router.transitionTo('supervision.submissions');
+      console.warn('No submission document. Transitioning to index.');
+      return this.router.transitionTo('search.submissions');
     }
 
     const response = yield fetch(`/submission-forms/${submissionDocument.id}`);

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -1,8 +1,8 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Account extends Model {
-  @attr() voId;
-  @attr() provider;
+  @attr voId;
+  @attr provider;
 
-  @belongsTo('gebruiker', { inverse: null }) gebruiker;
+  @belongsTo('gebruiker', { async: false, inverse: null }) gebruiker;
 }

--- a/app/models/bestuurseenheid-classificatie-code.js
+++ b/app/models/bestuurseenheid-classificatie-code.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class BestuurseenheidClassificatieCode extends Model {
-  @attr() label;
-  @attr() scopeNote;
-  @attr() uri;
+  @attr label;
+  @attr scopeNote;
+  @attr uri;
 }

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -1,16 +1,28 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class Bestuurseenheid extends Model {
-  @attr() naam;
+  @attr naam;
   @attr('string-set') alternatieveNaam;
 
-  @belongsTo('werkingsgebied', { inverse: null }) werkingsgebied;
-  @belongsTo('werkingsgebied', { inverse: null }) provincie;
-  @belongsTo('bestuurseenheid-classificatie-code', { inverse: null })
+  @belongsTo('werkingsgebied', { async: false, inverse: 'bestuurseenheid' })
+  werkingsgebied;
+
+  @belongsTo('werkingsgebied', {
+    async: false,
+    inverse: 'bestuurseenhedenInProvincie',
+  })
+  provincie;
+
+  @belongsTo('bestuurseenheid-classificatie-code', {
+    async: false,
+    inverse: null,
+  })
   classificatie;
-  @hasMany('bestuursorgaan', { inverse: null }) bestuursorganen;
+
+  @hasMany('bestuursorgaan', { async: false, inverse: 'bestuurseenheid' })
+  bestuursorganen;
 
   get fullName() {
-    return `${this.classificatie.get('label')} ${this.naam}`.trim();
+    return `${this.classificatie.label} ${this.naam}`.trim();
   }
 }

--- a/app/models/bestuursorgaan-classificatie-code.js
+++ b/app/models/bestuursorgaan-classificatie-code.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class BestuursorgaanClassificatieCode extends Model {
-  @attr() uri;
-  @attr() label;
-  @attr() scopeNote;
+  @attr uri;
+  @attr label;
+  @attr scopeNote;
 }

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -1,14 +1,23 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class Bestuursorgaan extends Model {
-  @attr() uri;
-  @attr() naam;
+  @attr uri;
+  @attr naam;
   @attr('date') bindingStart;
   @attr('date') bindingEinde;
 
-  @belongsTo('bestuurseenheid', { inverse: null }) bestuurseenheid;
-  @belongsTo('bestuursorgaan-classificatie-code', { inverse: null })
+  @belongsTo('bestuurseenheid', { async: true, inverse: 'bestuursorganen' })
+  bestuurseenheid;
+
+  @belongsTo('bestuursorgaan-classificatie-code', {
+    async: true,
+    inverse: null,
+  })
   classificatie;
-  @belongsTo('bestuursorgaan', { inverse: null }) isTijdsspecialisatieVan;
-  @hasMany('bestuursorgaan', { inverse: null }) heeftTijdsspecialisaties;
+
+  @belongsTo('bestuursorgaan', { async: true, inverse: null })
+  isTijdsspecialisatieVan;
+
+  @hasMany('bestuursorgaan', { async: true, inverse: null })
+  heeftTijdsspecialisaties;
 }

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -12,6 +12,7 @@ export const CHART_OF_ACCOUNT =
 export default class ConceptSchemeModel extends Model {
   @attr uri;
 
-  @hasMany('concept', { inverse: null }) concepts;
-  @hasMany('concept', { inverse: null }) topConcepts;
+  @hasMany('concept', { async: true, inverse: 'conceptSchemes' }) concepts;
+  @hasMany('concept', { async: true, inverse: 'topConceptSchemes' })
+  topConcepts;
 }

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -14,8 +14,11 @@ export default class ConceptModel extends Model {
   @attr notation;
   @attr searchLabel;
 
-  @hasMany('concept-scheme', { inverse: null }) conceptSchemes;
-  @hasMany('concept-scheme', { inverse: null }) topConceptSchemes;
+  @hasMany('concept-scheme', { async: true, inverse: 'concepts' })
+  conceptSchemes;
+
+  @hasMany('concept-scheme', { async: true, inverse: 'topConcepts' })
+  topConceptSchemes;
 
   get isRegulation() {
     return (

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -1,11 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class File extends Model {
-  @attr() uri;
-  @attr() filename;
-  @attr() format;
-  @attr() size;
-  @attr('string', { defaultValue: 'n/a' }) extension;
+  @attr uri;
+  @attr filename;
+  @attr format;
+  @attr size;
+  @attr({ defaultValue: 'n/a' }) extension;
   @attr('datetime') created;
 
   get humanReadableSize() {

--- a/app/models/form-data.js
+++ b/app/models/form-data.js
@@ -15,11 +15,11 @@ export default class FormDataModel extends Model {
   @attr taxRateAmmount;
   @attr sessionStartedAtTime;
 
-  @hasMany('concept') types;
-  @belongsTo('submission') submission;
-  @belongsTo('bestuurseenheid') isAbout;
-  @belongsTo('bestuursorgaan') passedBy;
-  @belongsTo('chart-of-account') chartOfAccount;
-  @belongsTo('concept') decisionType;
-  @belongsTo('concept') regulationType;
+  @hasMany('concept', { async: false, inverse: null }) types;
+  @belongsTo('submission', { async: true, inverse: 'formData' }) submission;
+  @belongsTo('bestuurseenheid', { async: true, inverse: null }) isAbout;
+  @belongsTo('bestuursorgaan', { async: true, inverse: null }) passedBy;
+  @belongsTo('chart-of-account', { async: true, inverse: null }) chartOfAccount;
+  @belongsTo('concept', { async: true, inverse: null }) decisionType;
+  @belongsTo('concept', { async: true, inverse: null }) regulationType;
 }

--- a/app/models/gebruiker.js
+++ b/app/models/gebruiker.js
@@ -2,16 +2,14 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Gebruiker extends Model {
   @attr uri;
+  @attr voornaam;
+  @attr achternaam;
 
-  @attr() voornaam;
-  @attr() achternaam;
-
-  @hasMany('account', { inverse: null }) account;
-  @hasMany('bestuurseenheid') bestuurseenheden;
-  @hasMany('search-query') searchQueries;
+  @hasMany('bestuurseenheid', { async: false, inverse: null }) bestuurseenheden;
+  @hasMany('search-query', { async: true, inverse: 'user' }) searchQueries;
 
   get group() {
-    return this.bestuurseenheden.firstObject;
+    return this.bestuurseenheden.at(0);
   }
 
   get fullName() {

--- a/app/models/remote-url.js
+++ b/app/models/remote-url.js
@@ -8,7 +8,7 @@ export default class AutomaticSubmissionTask extends Model {
   @attr downloadStatus;
   @attr creator;
 
-  @belongsTo('file', { inverse: null }) download;
+  @belongsTo('file', { async: true, inverse: null }) download;
 
   get downloadLink() {
     return `/files/${this.id}/download`;

--- a/app/models/search-query.js
+++ b/app/models/search-query.js
@@ -1,9 +1,9 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class SearchQueryModel extends Model {
-  @attr() uri;
-  @attr() label;
-  @attr() comment;
+  @attr uri;
+  @attr label;
+  @attr comment;
   @attr('datetime', {
     defaultValue() {
       return new Date();
@@ -11,5 +11,5 @@ export default class SearchQueryModel extends Model {
   })
   created;
 
-  @belongsTo('gebruiker', { inverse: null }) user;
+  @belongsTo('gebruiker', { async: true, inverse: 'searchQueries' }) user;
 }

--- a/app/models/submission-document.js
+++ b/app/models/submission-document.js
@@ -3,5 +3,6 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class SubmissionDocument extends Model {
   @attr uri;
 
-  @belongsTo('submission') submission;
+  @belongsTo('submission', { async: false, inverse: 'submissionDocument' })
+  submission;
 }

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -7,19 +7,24 @@ export default class Submission extends Model {
     },
   })
   created;
+
   @attr('datetime', {
     defaultValue() {
       return new Date();
     },
   })
   modified;
+
   @attr('datetime') sentDate;
   @attr('datetime') receivedDate;
   @attr source;
   @attr uri;
   @attr href;
-  @belongsTo('form-data') formData;
-  @belongsTo('bestuurseenheid') organization;
-  @belongsTo('submission-document') submissionDocument;
-  @hasMany('file') files;
+  @belongsTo('form-data', { async: false, inverse: 'submission' }) formData;
+  @belongsTo('bestuurseenheid', { async: false, inverse: null }) organization;
+
+  @belongsTo('submission-document', { async: false, inverse: 'submission' })
+  submissionDocument;
+
+  @hasMany('file', { async: true, inverse: null }) files;
 }

--- a/app/models/tax-type.js
+++ b/app/models/tax-type.js
@@ -1,5 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class TaxType extends Model {
-  @attr('string') label;
+  @attr label;
 }

--- a/app/models/werkingsgebied.js
+++ b/app/models/werkingsgebied.js
@@ -1,12 +1,15 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Werkingsgebied extends Model {
-  @attr() uri;
-  @attr() naam;
-  @attr() niveau;
+  @attr uri;
+  @attr naam;
+  @attr niveau;
 
-  @hasMany('bestuurseenheid', { inverse: null }) bestuurseenheid;
-  @hasMany('bestuurseenheid', { inverse: null }) bestuurseenhedenInProvincie;
+  @hasMany('bestuurseenheid', { async: true, inverse: 'werkingsgebied' })
+  bestuurseenheid;
+
+  @hasMany('bestuurseenheid', { async: true, inverse: 'provincie' })
+  bestuurseenhedenInProvincie;
 
   get longName() {
     let niveau = this.niveau;

--- a/app/routes/search/submissions/show.js
+++ b/app/routes/search/submissions/show.js
@@ -6,12 +6,7 @@ export default class SearchSubmissionsShowRoute extends Route {
 
   model(params) {
     return this.store.findRecord('submission', params.id, {
-      include: [
-        'organization.classificatie',
-        'organization.provincie',
-        'form-data.types',
-        'last-modifier',
-      ].join(','),
+      include: ['organization.classificatie'].join(','),
     });
   }
 }

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -22,17 +22,16 @@
                   <p>
                   {{account.gebruiker.voornaam}} {{account.gebruiker.achternaam}}
                   </p>
-                  {{! template-lint-configure no-array-prototype-extensions "warn"}} {{! TODO: fix this when resolving Ember Data deprecations}}
-                  {{#if (await account.gebruiker.bestuurseenheden.firstObject.alternatieveNaam)}}
-                  <AuHr/>
-                  <p>
-                    <span class="au-c-info-text">Alternatieve naam:</span>
-                    {{#each (await account.gebruiker.bestuurseenheden) as |bestuurseenheid|}}
-                      {{#each bestuurseenheid.alternatieveNaam as |alternatieveNaam|}}
-                        <AuPill>{{alternatieveNaam}}</AuPill>
+                  {{#if account.gebruiker.group.alternatieveNaam}}
+                    <AuHr/>
+                    <p>
+                      <span class="au-c-info-text">Alternatieve naam:</span>
+                      {{#each account.gebruiker.bestuurseenheden as |bestuurseenheid|}}
+                        {{#each bestuurseenheid.alternatieveNaam as |alternatieveNaam|}}
+                          <AuPill>{{alternatieveNaam}}</AuPill>
+                        {{/each}}
                       {{/each}}
-                    {{/each}}
-                  </p>
+                    </p>
                   {{/if}}
                 </div>
             </login.each-account>


### PR DESCRIPTION
- resolve deprecations by adding explicit async and inverse values
- convert relationships to sync where possible. This makes the code easier to reason about since we no longer need to handle the async before accessing relationships.

The sync relationship change introduces a lot of warnings like this (in development):

> WARNING: You pushed a record of type 'bestuurseenheid' with a relationship 'bestuursorganen' configured as 'async: false'. You've included a link but no primary data, this may be an error in your payload. EmberData will treat this relationship as known-to-be-empty.

This is not an issue (besides having to use `.reload` instead of `.load` when loading a relationship). EmberData makes the assumption that a relationship is empty if the server doesn't include any ids in the response, but only including the link is perfectly valid according to the json:api spec. There are plans to change that behavior so it shouldn't be as noisy in future ED versions.